### PR TITLE
ADM remediating 12 vulnerable artifacts

### DIFF
--- a/cachecloud-web/pom.xml
+++ b/cachecloud-web/pom.xml
@@ -19,14 +19,14 @@
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
-                <version>${spring.boot.version}</version>
+                <version>2.6.15</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-dependencies</artifactId>
-                <version>${spring.cloud.version}</version>
+                <version>2020.0.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -174,7 +174,7 @@
         <dependency>
             <groupId>com.zaxxer</groupId>
             <artifactId>HikariCP</artifactId>
-            <version>3.3.1</version>
+            <version>3.4.0</version>
         </dependency>
 
         <dependency>
@@ -217,7 +217,7 @@
         <dependency>
             <groupId>net.logstash.logback</groupId>
             <artifactId>logstash-logback-encoder</artifactId>
-            <version>${logstash-logback-encoder.version}</version>
+            <version>7.3</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
             <dependency>
                 <groupId>org.quartz-scheduler</groupId>
                 <artifactId>quartz</artifactId>
-                <version>${quartz.version}</version>
+                <version>2.3.2</version>
                 <exclusions>
                     <exclusion>
                         <artifactId>slf4j-api</artifactId>
@@ -69,14 +69,14 @@
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
-                <version>${logback.version}</version>
+                <version>1.2.12</version>
                 <scope>compile</scope>
             </dependency>
 
             <dependency>
                 <groupId>mysql</groupId>
                 <artifactId>mysql-connector-java</artifactId>
-                <version>${mysql.java.version}</version>
+                <version>8.0.31</version>
             </dependency>
 
             <dependency>
@@ -125,7 +125,7 @@
             <dependency>
                 <groupId>com.hierynomus</groupId>
                 <artifactId>sshj</artifactId>
-                <version>${sshj.version}</version>
+                <version>0.31.0</version>
             </dependency>
 
             <dependency>
@@ -156,7 +156,7 @@
             <dependency>
                 <groupId>commons-configuration</groupId>
                 <artifactId>commons-configuration</artifactId>
-                <version>${commons.configuration.version}</version>
+                <version>20030311.152757</version>
             </dependency>
 
             <dependency>
@@ -168,7 +168,7 @@
             <dependency>
                 <groupId>com.netflix.hystrix</groupId>
                 <artifactId>hystrix-core</artifactId>
-                <version>${hystrix.version}</version>
+                <version>1.5.7</version>
             </dependency>
 
             <dependency>
@@ -194,13 +194,13 @@
             <dependency>
                 <groupId>com.alibaba</groupId>
                 <artifactId>druid</artifactId>
-                <version>${druid-version}</version>
+                <version>1.2.4</version>
             </dependency>
 
             <dependency>
                 <groupId>org.mybatis.spring.boot</groupId>
                 <artifactId>mybatis-spring-boot-starter</artifactId>
-                <version>${mybatis-spring-boot.version}</version>
+                <version>2.3.1</version>
             </dependency>
 
             <!-- sohu dependency -->
@@ -218,7 +218,7 @@
             <dependency>
                 <groupId>io.springfox</groupId>
                 <artifactId>springfox-swagger-ui</artifactId>
-                <version>${swagger-ui.version}</version>
+                <version>2.10.0</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Vulnerabilities: [Remediation Run Detect Stage](https://cloud.oracle.com/adm/remediationRecipes/ocid1.admremediationrecipe.oc1.iad.amaaaaaa5f5ialyagcirrxnnwpwpsulpu3auwsizib4rw2boyt3zvcurtjya/runs/ocid1.admremediationrun.oc1.iad.amaaaaaa5f5ialyaxnpq2lkhuyvq7ychi3n5kt6ykv3pxvm3zelbubp7kyiq/stages/DETECT)
* com.sohu.tv.custom:cachecloud-custom:1.0-SNAPSHOT
  * org.springframework.boot:spring-boot-starter-web:2.2.9.RELEASE
    * CVE-2022-22965
    * ch.qos.logback:logback-core:1.2.3
      * CVE-2021-42550
    * com.fasterxml.jackson.core:jackson-databind:2.10.5
      * CVE-2020-25649
      * CVE-2020-36518
      * CVE-2021-46877
      * CVE-2022-42003
      * CVE-2022-42004
    * org.apache.tomcat.embed:tomcat-embed-core:9.0.37
      * CVE-2020-13943
      * CVE-2020-17527
      * CVE-2021-24122
      * CVE-2021-25122
      * CVE-2021-25329
      * CVE-2021-30640
      * CVE-2021-33037
    * org.springframework.boot:spring-boot:2.2.9.RELEASE
      * CVE-2022-27772
    * org.springframework:spring-beans:5.2.8.RELEASE
      * CVE-2022-22965
    * org.springframework:spring-core:5.2.8.RELEASE
      * CVE-2016-1000027
      * CVE-2021-22060
      * CVE-2021-22096
      * CVE-2022-22950
      * CVE-2022-22968
      * CVE-2022-22970
      * CVE-2022-22971
      * CVE-2023-20861
    * org.springframework:spring-web:5.2.8.RELEASE
      * CVE-2020-5421
      * CVE-2021-22118
    * org.springframework:spring-webmvc:5.2.8.RELEASE
      * CVE-2020-5421
      * CVE-2022-22965
    * org.yaml:snakeyaml:1.25
      * CVE-2017-18640
      * CVE-2022-1471
      * CVE-2022-25857
      * CVE-2022-38749
      * CVE-2022-38750
      * CVE-2022-38751
      * CVE-2022-38752
      * CVE-2022-41854
* com.sohu.tv:cachecloud-web:1.0-SNAPSHOT
  * ch.qos.logback:logback-classic:1.2.11
    * ch.qos.logback:logback-core:1.2.3
      * CVE-2021-42550
  * com.alibaba:druid:1.1.3
    * CVE-2021-33800
  * com.hierynomus:sshj:0.26.0
    * org.bouncycastle:bcprov-jdk15on:1.60
      * CVE-2020-15522
  * com.netflix.hystrix:hystrix-core:1.5.6
    * com.fasterxml.jackson.core:jackson-databind:2.10.5
      * CVE-2020-25649
      * CVE-2020-36518
      * CVE-2021-46877
      * CVE-2022-42003
      * CVE-2022-42004
    * commons-beanutils:commons-beanutils-core:1.8.0
      * CVE-2014-0114
    * commons-beanutils:commons-beanutils:1.8.0
      * CVE-2014-0114
      * CVE-2019-10086
    * commons-collections:commons-collections:3.2.1
      * CVE-2015-6420
      * CVE-2015-7501
  * com.sohu.tv.custom:cachecloud-custom:1.0-SNAPSHOT
    * c3p0:c3p0:0.9.1.1
      * CVE-2019-5427
    * ch.qos.logback:logback-core:1.2.3
      * CVE-2021-42550
    * com.fasterxml.jackson.core:jackson-databind:2.10.5
      * CVE-2020-25649
      * CVE-2020-36518
      * CVE-2021-46877
      * CVE-2022-42003
      * CVE-2022-42004
    * commons-beanutils:commons-beanutils-core:1.8.0
      * CVE-2014-0114
    * commons-beanutils:commons-beanutils:1.8.0
      * CVE-2014-0114
      * CVE-2019-10086
    * commons-collections:commons-collections:3.2.1
      * CVE-2015-6420
      * CVE-2015-7501
    * org.apache.tomcat.embed:tomcat-embed-core:9.0.37
      * CVE-2020-13943
      * CVE-2020-17527
      * CVE-2021-24122
      * CVE-2021-25122
      * CVE-2021-25329
      * CVE-2021-30640
      * CVE-2021-33037
    * org.quartz-scheduler:quartz:2.2.1
      * CVE-2019-13990
    * org.springframework.boot:spring-boot-starter-web:2.2.9.RELEASE
      * CVE-2022-22965
    * org.springframework.boot:spring-boot:2.2.9.RELEASE
      * CVE-2022-27772
    * org.springframework:spring-beans:5.2.8.RELEASE
      * CVE-2022-22965
    * org.springframework:spring-core:5.2.8.RELEASE
      * CVE-2016-1000027
      * CVE-2021-22060
      * CVE-2021-22096
      * CVE-2022-22950
      * CVE-2022-22968
      * CVE-2022-22970
      * CVE-2022-22971
      * CVE-2023-20861
    * org.springframework:spring-web:5.2.8.RELEASE
      * CVE-2020-5421
      * CVE-2021-22118
    * org.springframework:spring-webmvc:5.2.8.RELEASE
      * CVE-2020-5421
      * CVE-2022-22965
    * org.yaml:snakeyaml:1.25
      * CVE-2017-18640
      * CVE-2022-1471
      * CVE-2022-25857
      * CVE-2022-38749
      * CVE-2022-38750
      * CVE-2022-38751
      * CVE-2022-38752
      * CVE-2022-41854
  * com.zaxxer:HikariCP:3.3.1
    * ch.qos.logback:logback-core:1.2.3
      * CVE-2021-42550
    * com.fasterxml.jackson.core:jackson-databind:2.10.5
      * CVE-2020-25649
      * CVE-2020-36518
      * CVE-2021-46877
      * CVE-2022-42003
      * CVE-2022-42004
    * commons-beanutils:commons-beanutils-core:1.8.0
      * CVE-2014-0114
    * commons-beanutils:commons-beanutils:1.8.0
      * CVE-2014-0114
      * CVE-2019-10086
    * commons-collections:commons-collections:3.2.1
      * CVE-2015-6420
      * CVE-2015-7501
    * org.apache.tomcat.embed:tomcat-embed-core:9.0.37
      * CVE-2020-13943
      * CVE-2020-17527
      * CVE-2021-24122
      * CVE-2021-25122
      * CVE-2021-25329
      * CVE-2021-30640
      * CVE-2021-33037
  * commons-configuration:commons-configuration:1.6
    * commons-beanutils:commons-beanutils-core:1.8.0
      * CVE-2014-0114
    * commons-beanutils:commons-beanutils:1.8.0
      * CVE-2014-0114
      * CVE-2019-10086
    * commons-collections:commons-collections:3.2.1
      * CVE-2015-6420
      * CVE-2015-7501
  * io.springfox:springfox-swagger-ui:2.9.2
    * org.springframework:spring-beans:5.2.8.RELEASE
      * CVE-2022-22965
    * org.springframework:spring-core:5.2.8.RELEASE
      * CVE-2016-1000027
      * CVE-2021-22060
      * CVE-2021-22096
      * CVE-2022-22950
      * CVE-2022-22968
      * CVE-2022-22970
      * CVE-2022-22971
      * CVE-2023-20861
  * io.springfox:springfox-swagger2:2.9.2
    * org.springframework:spring-beans:5.2.8.RELEASE
      * CVE-2022-22965
    * org.springframework:spring-core:5.2.8.RELEASE
      * CVE-2016-1000027
      * CVE-2021-22060
      * CVE-2021-22096
      * CVE-2022-22950
      * CVE-2022-22968
      * CVE-2022-22970
      * CVE-2022-22971
      * CVE-2023-20861
  * mysql:mysql-connector-java:8.0.29
    * com.google.protobuf:protobuf-java:3.11.4
      * CVE-2021-22569
      * CVE-2022-3171
      * CVE-2022-3509
      * CVE-2022-3510
  * net.logstash.logback:logstash-logback-encoder:5.3
    * ch.qos.logback:logback-core:1.2.3
      * CVE-2021-42550
    * com.fasterxml.jackson.core:jackson-databind:2.10.5
      * CVE-2020-25649
      * CVE-2020-36518
      * CVE-2021-46877
      * CVE-2022-42003
      * CVE-2022-42004
  * net.sf.json-lib:json-lib:2.4
    * commons-beanutils:commons-beanutils:1.8.0
      * CVE-2014-0114
      * CVE-2019-10086
    * commons-collections:commons-collections:3.2.1
      * CVE-2015-6420
      * CVE-2015-7501
  * org.apache.struts:struts-taglib:1.3.10
    * CVE-2016-1181
    * CVE-2016-1182
    * commons-beanutils:commons-beanutils:1.8.0
      * CVE-2014-0114
      * CVE-2019-10086
    * commons-collections:commons-collections:3.2.1
      * CVE-2015-6420
      * CVE-2015-7501
    * org.apache.struts:struts-core:1.3.10
      * CVE-2012-1007
      * CVE-2015-0899
      * CVE-2016-1181
      * CVE-2016-1182
  * org.apache.tomcat.embed:tomcat-embed-jasper:9.0.37
    * org.apache.tomcat.embed:tomcat-embed-core:9.0.37
      * CVE-2020-13943
      * CVE-2020-17527
      * CVE-2021-24122
      * CVE-2021-25122
      * CVE-2021-25329
      * CVE-2021-30640
      * CVE-2021-33037
  * org.mybatis.spring.boot:mybatis-spring-boot-starter:1.3.1
    * c3p0:c3p0:0.9.1.1
      * CVE-2019-5427
    * ch.qos.logback:logback-core:1.2.3
      * CVE-2021-42550
    * com.fasterxml.jackson.core:jackson-databind:2.10.5
      * CVE-2020-25649
      * CVE-2020-36518
      * CVE-2021-46877
      * CVE-2022-42003
      * CVE-2022-42004
    * commons-beanutils:commons-beanutils-core:1.8.0
      * CVE-2014-0114
    * commons-beanutils:commons-beanutils:1.8.0
      * CVE-2014-0114
      * CVE-2019-10086
    * commons-collections:commons-collections:3.2.1
      * CVE-2015-6420
      * CVE-2015-7501
    * org.apache.tomcat.embed:tomcat-embed-core:9.0.37
      * CVE-2020-13943
      * CVE-2020-17527
      * CVE-2021-24122
      * CVE-2021-25122
      * CVE-2021-25329
      * CVE-2021-30640
      * CVE-2021-33037
    * org.mybatis:mybatis:3.4.5
      * CVE-2020-26945
    * org.quartz-scheduler:quartz:2.2.1
      * CVE-2019-13990
    * org.springframework.boot:spring-boot:2.2.9.RELEASE
      * CVE-2022-27772
    * org.springframework:spring-beans:5.2.8.RELEASE
      * CVE-2022-22965
    * org.springframework:spring-core:5.2.8.RELEASE
      * CVE-2016-1000027
      * CVE-2021-22060
      * CVE-2021-22096
      * CVE-2022-22950
      * CVE-2022-22968
      * CVE-2022-22970
      * CVE-2022-22971
      * CVE-2023-20861
    * org.springframework:spring-web:5.2.8.RELEASE
      * CVE-2020-5421
      * CVE-2021-22118
    * org.springframework:spring-webmvc:5.2.8.RELEASE
      * CVE-2020-5421
      * CVE-2022-22965
    * org.yaml:snakeyaml:1.25
      * CVE-2017-18640
      * CVE-2022-1471
      * CVE-2022-25857
      * CVE-2022-38749
      * CVE-2022-38750
      * CVE-2022-38751
      * CVE-2022-38752
      * CVE-2022-41854
  * org.quartz-scheduler:quartz:2.2.1
    * CVE-2019-13990
    * c3p0:c3p0:0.9.1.1
      * CVE-2019-5427
  * org.springframework.boot:spring-boot-starter-actuator:2.2.9.RELEASE
    * c3p0:c3p0:0.9.1.1
      * CVE-2019-5427
    * ch.qos.logback:logback-core:1.2.3
      * CVE-2021-42550
    * com.fasterxml.jackson.core:jackson-databind:2.10.5
      * CVE-2020-25649
      * CVE-2020-36518
      * CVE-2021-46877
      * CVE-2022-42003
      * CVE-2022-42004
    * commons-beanutils:commons-beanutils-core:1.8.0
      * CVE-2014-0114
    * commons-beanutils:commons-beanutils:1.8.0
      * CVE-2014-0114
      * CVE-2019-10086
    * commons-collections:commons-collections:3.2.1
      * CVE-2015-6420
      * CVE-2015-7501
    * org.apache.tomcat.embed:tomcat-embed-core:9.0.37
      * CVE-2020-13943
      * CVE-2020-17527
      * CVE-2021-24122
      * CVE-2021-25122
      * CVE-2021-25329
      * CVE-2021-30640
      * CVE-2021-33037
    * org.quartz-scheduler:quartz:2.2.1
      * CVE-2019-13990
    * org.springframework.boot:spring-boot:2.2.9.RELEASE
      * CVE-2022-27772
    * org.springframework:spring-beans:5.2.8.RELEASE
      * CVE-2022-22965
    * org.springframework:spring-core:5.2.8.RELEASE
      * CVE-2016-1000027
      * CVE-2021-22060
      * CVE-2021-22096
      * CVE-2022-22950
      * CVE-2022-22968
      * CVE-2022-22970
      * CVE-2022-22971
      * CVE-2023-20861
    * org.springframework:spring-web:5.2.8.RELEASE
      * CVE-2020-5421
      * CVE-2021-22118
    * org.springframework:spring-webmvc:5.2.8.RELEASE
      * CVE-2020-5421
      * CVE-2022-22965
    * org.yaml:snakeyaml:1.25
      * CVE-2017-18640
      * CVE-2022-1471
      * CVE-2022-25857
      * CVE-2022-38749
      * CVE-2022-38750
      * CVE-2022-38751
      * CVE-2022-38752
      * CVE-2022-41854
  * org.springframework.boot:spring-boot-starter-freemarker:2.2.9.RELEASE
    * c3p0:c3p0:0.9.1.1
      * CVE-2019-5427
    * ch.qos.logback:logback-core:1.2.3
      * CVE-2021-42550
    * com.fasterxml.jackson.core:jackson-databind:2.10.5
      * CVE-2020-25649
      * CVE-2020-36518
      * CVE-2021-46877
      * CVE-2022-42003
      * CVE-2022-42004
    * commons-beanutils:commons-beanutils-core:1.8.0
      * CVE-2014-0114
    * commons-beanutils:commons-beanutils:1.8.0
      * CVE-2014-0114
      * CVE-2019-10086
    * commons-collections:commons-collections:3.2.1
      * CVE-2015-6420
      * CVE-2015-7501
    * org.apache.tomcat.embed:tomcat-embed-core:9.0.37
      * CVE-2020-13943
      * CVE-2020-17527
      * CVE-2021-24122
      * CVE-2021-25122
      * CVE-2021-25329
      * CVE-2021-30640
      * CVE-2021-33037
    * org.quartz-scheduler:quartz:2.2.1
      * CVE-2019-13990
    * org.springframework.boot:spring-boot:2.2.9.RELEASE
      * CVE-2022-27772
    * org.springframework:spring-beans:5.2.8.RELEASE
      * CVE-2022-22965
    * org.springframework:spring-core:5.2.8.RELEASE
      * CVE-2016-1000027
      * CVE-2021-22060
      * CVE-2021-22096
      * CVE-2022-22950
      * CVE-2022-22968
      * CVE-2022-22970
      * CVE-2022-22971
      * CVE-2023-20861
    * org.springframework:spring-web:5.2.8.RELEASE
      * CVE-2020-5421
      * CVE-2021-22118
    * org.springframework:spring-webmvc:5.2.8.RELEASE
      * CVE-2020-5421
      * CVE-2022-22965
    * org.yaml:snakeyaml:1.25
      * CVE-2017-18640
      * CVE-2022-1471
      * CVE-2022-25857
      * CVE-2022-38749
      * CVE-2022-38750
      * CVE-2022-38751
      * CVE-2022-38752
      * CVE-2022-41854
  * org.springframework.boot:spring-boot-starter-jdbc:2.2.9.RELEASE
    * c3p0:c3p0:0.9.1.1
      * CVE-2019-5427
    * ch.qos.logback:logback-core:1.2.3
      * CVE-2021-42550
    * com.fasterxml.jackson.core:jackson-databind:2.10.5
      * CVE-2020-25649
      * CVE-2020-36518
      * CVE-2021-46877
      * CVE-2022-42003
      * CVE-2022-42004
    * commons-beanutils:commons-beanutils-core:1.8.0
      * CVE-2014-0114
    * commons-beanutils:commons-beanutils:1.8.0
      * CVE-2014-0114
      * CVE-2019-10086
    * commons-collections:commons-collections:3.2.1
      * CVE-2015-6420
      * CVE-2015-7501
    * org.apache.tomcat.embed:tomcat-embed-core:9.0.37
      * CVE-2020-13943
      * CVE-2020-17527
      * CVE-2021-24122
      * CVE-2021-25122
      * CVE-2021-25329
      * CVE-2021-30640
      * CVE-2021-33037
    * org.quartz-scheduler:quartz:2.2.1
      * CVE-2019-13990
    * org.springframework.boot:spring-boot:2.2.9.RELEASE
      * CVE-2022-27772
    * org.springframework:spring-beans:5.2.8.RELEASE
      * CVE-2022-22965
    * org.springframework:spring-core:5.2.8.RELEASE
      * CVE-2016-1000027
      * CVE-2021-22060
      * CVE-2021-22096
      * CVE-2022-22950
      * CVE-2022-22968
      * CVE-2022-22970
      * CVE-2022-22971
      * CVE-2023-20861
    * org.springframework:spring-web:5.2.8.RELEASE
      * CVE-2020-5421
      * CVE-2021-22118
    * org.springframework:spring-webmvc:5.2.8.RELEASE
      * CVE-2020-5421
      * CVE-2022-22965
    * org.yaml:snakeyaml:1.25
      * CVE-2017-18640
      * CVE-2022-1471
      * CVE-2022-25857
      * CVE-2022-38749
      * CVE-2022-38750
      * CVE-2022-38751
      * CVE-2022-38752
      * CVE-2022-41854
  * org.springframework.boot:spring-boot-starter-logging:2.2.9.RELEASE
    * ch.qos.logback:logback-core:1.2.3
      * CVE-2021-42550
  * org.springframework.boot:spring-boot-starter-test:2.2.9.RELEASE
    * c3p0:c3p0:0.9.1.1
      * CVE-2019-5427
    * ch.qos.logback:logback-core:1.2.3
      * CVE-2021-42550
    * com.fasterxml.jackson.core:jackson-databind:2.10.5
      * CVE-2020-25649
      * CVE-2020-36518
      * CVE-2021-46877
      * CVE-2022-42003
      * CVE-2022-42004
    * commons-beanutils:commons-beanutils-core:1.8.0
      * CVE-2014-0114
    * commons-beanutils:commons-beanutils:1.8.0
      * CVE-2014-0114
      * CVE-2019-10086
    * commons-collections:commons-collections:3.2.1
      * CVE-2015-6420
      * CVE-2015-7501
    * net.minidev:json-smart:2.3
      * CVE-2021-27568
      * CVE-2023-1370
    * org.apache.tomcat.embed:tomcat-embed-core:9.0.37
      * CVE-2020-13943
      * CVE-2020-17527
      * CVE-2021-24122
      * CVE-2021-25122
      * CVE-2021-25329
      * CVE-2021-30640
      * CVE-2021-33037
    * org.quartz-scheduler:quartz:2.2.1
      * CVE-2019-13990
    * org.springframework.boot:spring-boot:2.2.9.RELEASE
      * CVE-2022-27772
    * org.springframework:spring-beans:5.2.8.RELEASE
      * CVE-2022-22965
    * org.springframework:spring-core:5.2.8.RELEASE
      * CVE-2016-1000027
      * CVE-2021-22060
      * CVE-2021-22096
      * CVE-2022-22950
      * CVE-2022-22968
      * CVE-2022-22970
      * CVE-2022-22971
      * CVE-2023-20861
    * org.springframework:spring-web:5.2.8.RELEASE
      * CVE-2020-5421
      * CVE-2021-22118
    * org.springframework:spring-webmvc:5.2.8.RELEASE
      * CVE-2020-5421
      * CVE-2022-22965
    * org.yaml:snakeyaml:1.25
      * CVE-2017-18640
      * CVE-2022-1471
      * CVE-2022-25857
      * CVE-2022-38749
      * CVE-2022-38750
      * CVE-2022-38751
      * CVE-2022-38752
      * CVE-2022-41854
  * org.springframework.boot:spring-boot-starter-web:2.2.9.RELEASE
    * CVE-2022-22965
    * c3p0:c3p0:0.9.1.1
      * CVE-2019-5427
    * ch.qos.logback:logback-core:1.2.3
      * CVE-2021-42550
    * com.fasterxml.jackson.core:jackson-databind:2.10.5
      * CVE-2020-25649
      * CVE-2020-36518
      * CVE-2021-46877
      * CVE-2022-42003
      * CVE-2022-42004
    * commons-beanutils:commons-beanutils-core:1.8.0
      * CVE-2014-0114
    * commons-beanutils:commons-beanutils:1.8.0
      * CVE-2014-0114
      * CVE-2019-10086
    * commons-collections:commons-collections:3.2.1
      * CVE-2015-6420
      * CVE-2015-7501
    * org.apache.tomcat.embed:tomcat-embed-core:9.0.37
      * CVE-2020-13943
      * CVE-2020-17527
      * CVE-2021-24122
      * CVE-2021-25122
      * CVE-2021-25329
      * CVE-2021-30640
      * CVE-2021-33037
    * org.quartz-scheduler:quartz:2.2.1
      * CVE-2019-13990
    * org.springframework.boot:spring-boot:2.2.9.RELEASE
      * CVE-2022-27772
    * org.springframework:spring-beans:5.2.8.RELEASE
      * CVE-2022-22965
    * org.springframework:spring-core:5.2.8.RELEASE
      * CVE-2016-1000027
      * CVE-2021-22060
      * CVE-2021-22096
      * CVE-2022-22950
      * CVE-2022-22968
      * CVE-2022-22970
      * CVE-2022-22971
      * CVE-2023-20861
    * org.springframework:spring-web:5.2.8.RELEASE
      * CVE-2020-5421
      * CVE-2021-22118
    * org.springframework:spring-webmvc:5.2.8.RELEASE
      * CVE-2020-5421
      * CVE-2022-22965
    * org.yaml:snakeyaml:1.25
      * CVE-2017-18640
      * CVE-2022-1471
      * CVE-2022-25857
      * CVE-2022-38749
      * CVE-2022-38750
      * CVE-2022-38751
      * CVE-2022-38752
      * CVE-2022-41854
  * org.springframework:spring-context-support:5.2.8.RELEASE
    * org.springframework:spring-beans:5.2.8.RELEASE
      * CVE-2022-22965
    * org.springframework:spring-core:5.2.8.RELEASE
      * CVE-2016-1000027
      * CVE-2021-22060
      * CVE-2021-22096
      * CVE-2022-22950
      * CVE-2022-22968
      * CVE-2022-22970
      * CVE-2022-22971
      * CVE-2023-20861

Dependencies upgraded: [Remediation Run Recommend Stage](https://cloud.oracle.com/adm/remediationRecipes/ocid1.admremediationrecipe.oc1.iad.amaaaaaa5f5ialyagcirrxnnwpwpsulpu3auwsizib4rw2boyt3zvcurtjya/runs/ocid1.admremediationrun.oc1.iad.amaaaaaa5f5ialyaxnpq2lkhuyvq7ychi3n5kt6ykv3pxvm3zelbubp7kyiq/stages/RECOMMEND)

* ch.qos.logback:logback-classic:1.2.11 -> 1.2.12
* ch.qos.logback:logback-classic:1.2.11 -> 1.2.12
* com.alibaba:druid:1.1.3 -> 1.2.4
* com.hierynomus:sshj:0.26.0 -> 0.31.0
* com.netflix.hystrix:hystrix-core:1.5.6 -> 1.5.7
* com.zaxxer:HikariCP:3.3.1 -> 3.4.0
* commons-configuration:commons-configuration:1.6 -> 20030311.152757
* io.springfox:springfox-swagger-ui:2.9.2 -> 2.10.0
* mysql:mysql-connector-java:8.0.29 -> 8.0.31
* net.logstash.logback:logstash-logback-encoder:5.3 -> 7.3
* org.mybatis.spring.boot:mybatis-spring-boot-starter:1.3.1 -> 2.3.1
* org.quartz-scheduler:quartz:2.2.1 -> 2.3.2

Auto-merge is disabled.